### PR TITLE
Update cli fn to work with script programs

### DIFF
--- a/pkg/run/fn/cli/cli.go
+++ b/pkg/run/fn/cli/cli.go
@@ -1,15 +1,13 @@
-// Package cli provides an Fn that runs an external command. The Fn will run the
-// command as an OS process and restart the command if it exits. The Fn will
-// provide input over stdin and read output from stdout. Inputs and outputs
-// should be expressed as single-line strings. Additionally, the Fn will read
-// from stderr and log it.
+// Package cli provides an Fn that runs an external command. If the command is
+// configured to be run as a script, a new instance of the script will be
+// created for each invocation. Otherwise, the command is expected to be long-
+// running and service many inputs, though it will only provided a single input
+// to process at a time. This Fn provides process-level isolation. If a long-
+// running command exits, it will be restarted.
 //
-// Although the Fn will restart a command if it crashes, this functionality
-// should not be used to execute applications that exit successfully after
-// processing a single input. Doing so will cause a race condition within the
-// Fn as it takes nonzero time to detect that the application has exited
-// successfully and can be in a bad state if a subsequent Invoke call is made
-// before the process is cleaned up properly.
+// The cli fn will provide input over stdin and read output from stdout. Inputs
+// and outputs should be expressed as single-line strings. Additionally, the Fn
+// will read from stderr and log it to the runner's stdout stream.
 //
 // Systems that use this as the base Fn will have developers write functions as
 // CLI applications using any technology that can read and write standard
@@ -24,11 +22,9 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"sync"
 
 	"github.com/fnrun/fnrun/pkg/fn"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 	"github.com/tessellator/executil"
 )
 
@@ -46,160 +42,44 @@ func createBaseCmd(commandStr string, env ...string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-type simple struct {
-	alive         bool
-	baseCmd       *exec.Cmd
-	cmd           *exec.Cmd
-	errorChannel  chan error
-	outputChannel chan string
-	stdin         io.WriteCloser
-	locker        sync.RWMutex
-}
+func scanAndLogMessages(stream io.ReadCloser) error {
+	defer stream.Close()
 
-func (s *simple) setAlive(alive bool) error {
-	s.locker.Lock()
-	defer s.locker.Unlock()
-
-	if s.alive == alive {
-		return nil
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		log.Println(scanner.Text())
 	}
 
-	s.alive = alive
-
-	if !alive {
-		return s.cmd.Process.Kill()
-	}
-
-	return nil
-}
-
-func (s *simple) getAlive() bool {
-	s.locker.RLock()
-	defer s.locker.RUnlock()
-
-	return s.alive
+	return scanner.Err()
 }
 
 // ErrUnconfiguredCmd indicates that the CLI Fn has not been configured with
 // a command to run an external process.
 var ErrUnconfiguredCmd = fmt.Errorf("cli: unconfigured command")
 
-func (s *simple) start() error {
-	if s.getAlive() {
-		return nil
-	}
-	if s.baseCmd == nil {
-		return ErrUnconfiguredCmd
-	}
-
-	cmd := executil.CloneCmd(s.baseCmd)
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return err
-	}
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	err = cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	s.cmd = cmd
-	s.stdin = stdin
-	s.setAlive(true)
-
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			log.Println(scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			log.Printf("error reading message from cmd over stderr: %s\n", err)
-		}
-		if err := stderr.Close(); err != nil {
-			log.Println(err)
-		}
-	}()
-
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			s.outputChannel <- scanner.Text()
-		}
-		if err := scanner.Err(); err != nil {
-			s.errorChannel <- err
-		}
-	}()
-
-	go func() {
-		err := cmd.Wait()
-		s.setAlive(false)
-		if err != nil {
-			s.errorChannel <- err
-		}
-	}()
-
-	return nil
+type cliFn struct {
+	f fn.Fn
 }
 
-func (s *simple) kill() error {
-	return s.setAlive(false)
-}
-
-func (s *simple) Invoke(ctx context.Context, input interface{}) (interface{}, error) {
-	if err := s.start(); err != nil {
-		return nil, err
-	}
-
-	_, err := fmt.Fprintln(s.stdin, input)
-	if err != nil {
-		return nil, err
-	}
-
-	select {
-	case response := <-s.outputChannel:
-		return response, nil
-	case <-ctx.Done():
-		if err := s.kill(); err != nil {
-			return nil, err
-		}
-		return nil, ctx.Err()
-	case err = <-s.errorChannel:
-		if kerr := s.kill(); kerr != nil {
-			return nil, errors.Wrap(err, kerr.Error())
-		}
-		return nil, err
-	}
-}
-
-func (s *simple) RequiresConfig() bool {
+func (c *cliFn) RequiresConfig() bool {
 	return true
 }
 
-func (s *simple) ConfigureString(commandStr string) error {
+func (c *cliFn) ConfigureString(commandStr string) error {
 	cmd, err := createBaseCmd(commandStr)
 	if err != nil {
 		return err
 	}
 
-	s.baseCmd = cmd
+	c.f = newService(cmd)
 	return nil
 }
 
-func (s *simple) ConfigureMap(configMap map[string]interface{}) error {
+func (c *cliFn) ConfigureMap(configMap map[string]interface{}) error {
 	cfg := struct {
 		Command string   `mapstructure:"command"`
 		Env     []string `mapstructure:"env"`
+		Script  bool     `mapstructure:"script"`
 	}{}
 	err := mapstructure.Decode(configMap, &cfg)
 	if err != nil {
@@ -211,27 +91,26 @@ func (s *simple) ConfigureMap(configMap map[string]interface{}) error {
 		return err
 	}
 
-	s.baseCmd = baseCmd
+	if cfg.Script {
+		c.f = newScript(baseCmd)
+		return nil
+	}
+
+	c.f = newService(baseCmd)
 	return nil
+}
+
+func (c *cliFn) Invoke(ctx context.Context, input interface{}) (interface{}, error) {
+	if c.f == nil {
+		return nil, ErrUnconfiguredCmd
+	}
+
+	return c.f.Invoke(ctx, input)
 }
 
 // New creates an unconfigured Fn. The result of this function must be
 // configured with a command string, otherwise ErrUnconfiguredCmd will be
 // returned from calls to Invoke.
 func New() fn.Fn {
-	return &simple{
-		alive:         false,
-		errorChannel:  make(chan error, 1),
-		outputChannel: make(chan string, 1),
-	}
-}
-
-// NewFromCmd builds an Fn based on baseCmd.
-func NewFromCmd(baseCmd *exec.Cmd) fn.Fn {
-	return &simple{
-		alive:         false,
-		baseCmd:       executil.CloneCmd(baseCmd),
-		errorChannel:  make(chan error, 1),
-		outputChannel: make(chan string, 1),
-	}
+	return &cliFn{}
 }

--- a/pkg/run/fn/cli/cli_test.go
+++ b/pkg/run/fn/cli/cli_test.go
@@ -1,177 +1,95 @@
-package cli_test
+package cli
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
-	"time"
 
-	"github.com/fnrun/fnrun/pkg/fn"
 	"github.com/fnrun/fnrun/pkg/run/config"
-	"github.com/fnrun/fnrun/pkg/run/fn/cli"
-	"github.com/tessellator/executil"
 )
 
-func createBaseCmd(commandStr string, env ...string) (*exec.Cmd, error) {
-	cmd, err := executil.ParseCmd(commandStr)
-	if err != nil {
-		return nil, err
-	}
-
-	cmd.Env = os.Environ()
-	for _, envVar := range env {
-		cmd.Env = append(cmd.Env, envVar)
-	}
-
-	return cmd, nil
-}
-
-func newSubprocessFn(t *testing.T) fn.Fn {
-	t.Helper()
-
-	commandStr := fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperSubprocess")
-	env := []string{"GO_RUNNING_SUBPROCESS=1"}
-
-	baseCmd, err := createBaseCmd(commandStr, env...)
-	if err != nil {
-		t.Fatalf("error creating cmd: %#v", err)
-	}
-
-	return cli.NewFromCmd(baseCmd)
-}
-
-func TestFn_Invoke_subprocessExitsUnsuccessfully(t *testing.T) {
-	f := newSubprocessFn(t)
-	ctx := context.Background()
-
-	output, err := f.Invoke(ctx, "exit_error")
-	if err == nil {
-		t.Errorf("expected Invoke to return error, but it did not")
-	}
-	if output != nil {
-		t.Errorf("Expected error to be nil but it was %+v", output)
-	}
-
-	t.Run("command restarts after exit", func(t *testing.T) {
-		output, err := f.Invoke(ctx, "second time")
-		if err != nil {
-			t.Errorf("Invoke returned error: %+v", err)
-		}
-
-		want := "from subprocess: second time"
-		got := output.(string)
-
-		if got != want {
-			t.Errorf("want: %q; got %q", want, got)
-		}
-	})
-}
-
-func TestFn_Invoke_subprocessDoesNotCrash(t *testing.T) {
-	f := newSubprocessFn(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	output, err := f.Invoke(ctx, "first time")
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	want := "from subprocess: first time"
-	got := output.(string)
-	if got != want {
-		t.Errorf("first time: want %q; got %q", want, got)
-	}
-
-	output, err = f.Invoke(ctx, "second time")
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	want = "from subprocess: second time"
-	got = output.(string)
-	if got != want {
-		t.Errorf("first time: want %q; got %q", want, got)
-	}
-}
-
-func TestFn_Invoke_hangingSubprocess(t *testing.T) {
-	f := newSubprocessFn(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	_, err := f.Invoke(ctx, "sleep")
-	if err != context.DeadlineExceeded {
-		t.Errorf("expected Invoke to return DeadlineExceeded but instead returned %+v", err)
-	}
-}
-
 func TestNew_withoutConfigReturnsUnconfiguredError(t *testing.T) {
-	f := cli.New()
+	f := New()
 	_, err := f.Invoke(context.Background(), "some input")
-	if err != cli.ErrUnconfiguredCmd {
+	if err != ErrUnconfiguredCmd {
 		t.Fatalf("expected Invoke to return ErrUnconfiguredCmd but returned: %+v", err)
 	}
 }
 
-func TestNew_withConfiguration(t *testing.T) {
+func TestNew_withStringConfiguration(t *testing.T) {
+	f := New().(*cliFn)
+	err := f.ConfigureString("./myprogram")
+	if err != nil {
+		t.Fatalf("ConfigureString returned error: %+v", err)
+	}
+
+	_, ok := f.f.(*service)
+	if !ok {
+		t.Errorf("expected fn to be a *service but was a %T", f.f)
+	}
+}
+
+func TestNew_withServiceMapConfiguration(t *testing.T) {
 	configMap := map[string]interface{}{
 		"command": fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperSubprocess"),
 		"env":     []string{"GO_RUNNING_SUBPROCESS=1"},
 	}
-	f := cli.New()
+	f := New().(*cliFn)
 	err := config.Configure(f, configMap)
 	if err != nil {
 		t.Fatalf("Configure returned err: %+v", err)
 	}
 
-	output, err := f.Invoke(context.Background(), "some input")
+	_, ok := f.f.(*service)
+	if !ok {
+		t.Errorf("expected fn to be a *service but was %T", f.f)
+	}
+}
+
+func TestNew_withScriptConfiguration(t *testing.T) {
+	configMap := map[string]interface{}{
+		"command": fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperSubprocess"),
+		"env":     []string{"GO_RUNNING_SUBPROCESS=1"},
+		"script":  true,
+	}
+	f := New().(*cliFn)
+	err := config.Configure(f, configMap)
 	if err != nil {
-		t.Fatalf("Invoke returned err: %+v", err)
+		t.Fatalf("Configure returned err: %+v", err)
 	}
 
-	want := "from subprocess: some input"
-	got := output.(string)
-
-	if got != want {
-		t.Errorf("Unexpected output from Invoke: want %q, got %q", want, got)
+	_, ok := f.f.(*script)
+	if !ok {
+		t.Errorf("expected fn to be a *script but was %T", f.f)
 	}
 }
 
 func TestNew_withNilConfig(t *testing.T) {
-	f := cli.New()
+	f := New()
 	err := config.Configure(f, nil)
 	if err == nil {
 		t.Errorf("expected Configure to return an error but was nil")
 	}
 }
 
-// -----------------------------------------------------------------------------
-
-func Test_HelperSubprocess(t *testing.T) {
-	if os.Getenv("GO_RUNNING_SUBPROCESS") != "1" {
-		return
+func TestCliFn_Invoke(t *testing.T) {
+	configMap := map[string]interface{}{
+		"command": fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperSubprocess"),
+		"env":     []string{"GO_RUNNING_SUBPROCESS=1"},
+	}
+	f := New()
+	err := config.Configure(f, configMap)
+	if err != nil {
+		t.Fatalf("Configure returned err: %+v", err)
 	}
 
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
-		switch scanner.Text() {
-		case "sleep":
-			<-time.After(30 * time.Second)
-			fmt.Println("from subprocess")
-			break
-		case "exit_error":
-			fmt.Fprintln(os.Stderr, "from subprocess: exiting with error")
-			os.Exit(1)
-		default:
-			fmt.Printf("from subprocess: %s\n", scanner.Text())
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "received error: %#v", err)
-		os.Exit(1)
+	output, err := f.Invoke(context.Background(), "some input")
+
+	want := "from subprocess: some input"
+	got := output.(string)
+
+	if got != want {
+		t.Errorf("unexpected output: want %q, got %q", want, got)
 	}
 }

--- a/pkg/run/fn/cli/script.go
+++ b/pkg/run/fn/cli/script.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/tessellator/executil"
+)
+
+type script struct {
+	baseCmd *exec.Cmd
+}
+
+func (s *script) Invoke(ctx context.Context, input interface{}) (interface{}, error) {
+	cmd := executil.CloneCmd(s.baseCmd)
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	go scanAndLogMessages(stderr)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = fmt.Fprintln(stdin, input)
+	if err != nil {
+		return nil, err
+	}
+
+	outputChan := make(chan string)
+	errorChan := make(chan error)
+
+	go func() {
+		outputBytes, err := cmd.Output()
+		if err != nil {
+			errorChan <- err
+			return
+		}
+
+		outputChan <- string(outputBytes)
+	}()
+
+	select {
+	case <-ctx.Done():
+		cmd.Process.Kill()
+		return nil, ctx.Err()
+
+	case err := <-errorChan:
+		cmd.Process.Kill()
+		return nil, err
+
+	case result := <-outputChan:
+		return result, nil
+	}
+}
+
+func newScript(baseCmd *exec.Cmd) *script {
+	return &script{
+		baseCmd: baseCmd,
+	}
+}

--- a/pkg/run/fn/cli/script_test.go
+++ b/pkg/run/fn/cli/script_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScript_Invoke(t *testing.T) {
+	commandStr := fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperScript")
+	env := []string{"GO_RUNNING_SUBPROCESS=1"}
+
+	baseCmd, err := createBaseCmd(commandStr, env...)
+	if err != nil {
+		t.Fatalf("createBaseCmd returned error: %+v", err)
+	}
+
+	s := newScript(baseCmd)
+
+	iterations := 100
+	for i := 0; i < iterations; i++ {
+		output, err := s.Invoke(context.Background(), "some input")
+		if err != nil {
+			t.Fatalf("Invoke returned error on iteration %d: %+v", i, err)
+		}
+
+		outputStr := output.(string)
+
+		want := "from subprocess: some input"
+		got := strings.Split(outputStr, "\n")[0]
+
+		if got != want {
+			t.Errorf("Unexpected output from Invoke on iteration %d: want %q, got %q", i, want, got)
+		}
+	}
+}
+
+func TestScript_Invoke_crashingProcess(t *testing.T) {
+	commandStr := fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperScript")
+	env := []string{"GO_RUNNING_SUBPROCESS=1"}
+
+	baseCmd, err := createBaseCmd(commandStr, env...)
+	if err != nil {
+		t.Fatalf("createBaseCmd returned error: %+v", err)
+	}
+
+	s := newScript(baseCmd)
+
+	output, err := s.Invoke(context.Background(), "bad exit")
+	if err == nil {
+		t.Errorf("expected error from Invoke but did not receive one")
+	}
+	if output != nil {
+		t.Errorf("expected nil output but received: %#v", output)
+	}
+}
+
+func TestScript_Invoke_logsStderr(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+
+	commandStr := fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperScript")
+	env := []string{"GO_RUNNING_SUBPROCESS=1"}
+
+	baseCmd, err := createBaseCmd(commandStr, env...)
+	if err != nil {
+		t.Fatalf("createBaseCmd returned error: %+v", err)
+	}
+
+	s := newScript(baseCmd)
+
+	s.Invoke(context.Background(), "bad exit")
+
+	want := "bad exit on command!\n"
+	got := buf.String()
+
+	if got != want {
+		t.Errorf("did not capture log statement: want %q, got %q", want, got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+func Test_HelperScript(t *testing.T) {
+	if os.Getenv("GO_RUNNING_SUBPROCESS") != "1" {
+		return
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	ok := scanner.Scan()
+	if !ok {
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "received error: %+v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	input := scanner.Text()
+	if input == "bad exit" {
+		fmt.Fprintln(os.Stderr, "bad exit on command!")
+		fmt.Println("from subprocess: bad exit!")
+		os.Exit(1)
+	}
+
+	if input == "sleep" {
+		<-time.After(100 * time.Millisecond)
+	}
+
+	fmt.Printf("from subprocess: %s\n", scanner.Text())
+}

--- a/pkg/run/fn/cli/service.go
+++ b/pkg/run/fn/cli/service.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/tessellator/executil"
+)
+
+type service struct {
+	alive         bool
+	baseCmd       *exec.Cmd
+	cmd           *exec.Cmd
+	errorChannel  chan error
+	outputChannel chan string
+	stdin         io.WriteCloser
+	locker        sync.RWMutex
+}
+
+func (s *service) setAlive(alive bool) error {
+	s.locker.Lock()
+	defer s.locker.Unlock()
+
+	if s.alive == alive {
+		return nil
+	}
+
+	s.alive = alive
+
+	if !alive {
+		return s.cmd.Process.Kill()
+	}
+
+	return nil
+}
+
+func (s *service) getAlive() bool {
+	s.locker.RLock()
+	defer s.locker.RUnlock()
+
+	return s.alive
+}
+
+func (s *service) start() error {
+	if s.getAlive() {
+		return nil
+	}
+
+	cmd := executil.CloneCmd(s.baseCmd)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	s.cmd = cmd
+	s.stdin = stdin
+	s.setAlive(true)
+
+	go scanAndLogMessages(stderr)
+
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			s.outputChannel <- scanner.Text()
+		}
+		if err := scanner.Err(); err != nil {
+			s.errorChannel <- err
+		}
+	}()
+
+	go func() {
+		err := cmd.Wait()
+		s.setAlive(false)
+		if err != nil {
+			s.errorChannel <- err
+		}
+	}()
+
+	return nil
+}
+
+func (s *service) kill() error {
+	return s.setAlive(false)
+}
+
+func (s *service) Invoke(ctx context.Context, input interface{}) (interface{}, error) {
+	if err := s.start(); err != nil {
+		return nil, err
+	}
+
+	_, err := fmt.Fprintln(s.stdin, input)
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case response := <-s.outputChannel:
+		return response, nil
+	case <-ctx.Done():
+		if err := s.kill(); err != nil {
+			return nil, err
+		}
+		return nil, ctx.Err()
+	case err = <-s.errorChannel:
+		if kerr := s.kill(); kerr != nil {
+			return nil, errors.Wrap(err, kerr.Error())
+		}
+		return nil, err
+	}
+}
+
+func newService(baseCmd *exec.Cmd) *service {
+	return &service{
+		alive:         false,
+		baseCmd:       executil.CloneCmd(baseCmd),
+		errorChannel:  make(chan error, 1),
+		outputChannel: make(chan string, 1),
+	}
+}

--- a/pkg/run/fn/cli/service_test.go
+++ b/pkg/run/fn/cli/service_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fnrun/fnrun/pkg/fn"
+)
+
+func newSubprocessFn(t *testing.T) fn.Fn {
+	t.Helper()
+
+	commandStr := fmt.Sprintf("%s -test.run=%s", os.Args[0], "Test_HelperSubprocess")
+	env := []string{"GO_RUNNING_SUBPROCESS=1"}
+
+	baseCmd, err := createBaseCmd(commandStr, env...)
+	if err != nil {
+		t.Fatalf("error creating cmd: %#v", err)
+	}
+
+	return newService(baseCmd)
+}
+
+func TestService_Invoke(t *testing.T) {
+	f := newSubprocessFn(t)
+
+	iterations := 1000
+	for i := 0; i < iterations; i++ {
+		output, err := f.Invoke(context.Background(), "some input")
+		if err != nil {
+			t.Fatalf("Invoke returned err on iteration %d: %+v", i, err)
+		}
+
+		want := "from subprocess: some input"
+		got := output.(string)
+
+		if got != want {
+			t.Errorf("Unexpected output from Invoke on iteration %d: want %q, got %q", i, want, got)
+		}
+	}
+}
+
+func TestService_Invoke_subprocessExitsUnsuccessfully(t *testing.T) {
+	f := newSubprocessFn(t)
+	ctx := context.Background()
+
+	output, err := f.Invoke(ctx, "exit_error")
+	if err == nil {
+		t.Errorf("expected Invoke to return error, but it did not")
+	}
+	if output != nil {
+		t.Errorf("Expected error to be nil but it was %+v", output)
+	}
+
+	t.Run("command restarts after exit", func(t *testing.T) {
+		output, err := f.Invoke(ctx, "second time")
+		if err != nil {
+			t.Errorf("Invoke returned error: %+v", err)
+		}
+
+		want := "from subprocess: second time"
+		got := output.(string)
+
+		if got != want {
+			t.Errorf("want: %q; got %q", want, got)
+		}
+	})
+}
+
+func TestService_Invoke_subprocessDoesNotCrash(t *testing.T) {
+	f := newSubprocessFn(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	output, err := f.Invoke(ctx, "first time")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	want := "from subprocess: first time"
+	got := output.(string)
+	if got != want {
+		t.Errorf("first time: want %q; got %q", want, got)
+	}
+
+	output, err = f.Invoke(ctx, "second time")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	want = "from subprocess: second time"
+	got = output.(string)
+	if got != want {
+		t.Errorf("first time: want %q; got %q", want, got)
+	}
+}
+
+func TestService_Invoke_hangingSubprocess(t *testing.T) {
+	f := newSubprocessFn(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := f.Invoke(ctx, "sleep")
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected Invoke to return DeadlineExceeded but instead returned %+v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+func Test_HelperSubprocess(t *testing.T) {
+	if os.Getenv("GO_RUNNING_SUBPROCESS") != "1" {
+		return
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		switch scanner.Text() {
+		case "sleep":
+			<-time.After(30 * time.Second)
+			fmt.Println("from subprocess")
+			break
+		case "exit_error":
+			fmt.Fprintln(os.Stderr, "from subprocess: exiting with error")
+			os.Exit(1)
+		default:
+			fmt.Printf("from subprocess: %s\n", scanner.Text())
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "received error: %#v", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This PR adds functionality to the cli fn to execute programs that should be treated as scripts (that operate on a single input and then exit successfully). The default is still to treat programs as long-running, but this adds a new boolean configuration option `script` which will configure the fn to start the program on every invocation.