### PR TITLE
Remove token from codecov-action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,5 @@ jobs:
     - name: Upload Coverage report to CodeCov
       uses: codecov/codecov-action@v1.0.0
       with:
-        token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.out
         fail_ci_if_error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Test
       run: go test -v -race -cover -coverprofile=coverage.out ./...
     - name: Upload Coverage report to CodeCov
-      uses: codecov/codecov-action@v1.0.0
+      uses: codecov/codecov-action@v1
       with:
         file: ./coverage.out
         fail_ci_if_error: true


### PR DESCRIPTION
Since fnrun is a public repository, the codecov token is not necessary.