### PR TITLE
Fix invalid test for cron source

### DIFF
--- a/pkg/run/source/cron/cron_test.go
+++ b/pkg/run/source/cron/cron_test.go
@@ -10,8 +10,13 @@ import (
 	"github.com/fnrun/fnrun/pkg/run/config"
 )
 
+func nullInvokeFunc(context.Context, interface{}) (interface{}, error) {
+	return nil, nil
+}
+
 func TestInvoke(t *testing.T) {
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 
 	f := fn.NewFnFromInvokeFunc(func(context.Context, interface{}) (interface{}, error) {
 		wg.Done()
@@ -19,7 +24,9 @@ func TestInvoke(t *testing.T) {
 	})
 
 	m := New()
-	config.Configure(m, "1 * * * * *")
+	if err := config.Configure(m, "* * * * * *"); err != nil {
+		t.Fatalf("Configuring middleware returned error: %#v", err)
+	}
 
 	go func() {
 		m.Serve(context.Background(), f)
@@ -30,6 +37,33 @@ func TestInvoke(t *testing.T) {
 		t.Error("job did not run within two seconds")
 	case <-wait(wg):
 		break
+	}
+}
+
+func TestInvoke_withoutConfiguring(t *testing.T) {
+	m := New()
+	err := m.Serve(context.Background(), fn.NewFnFromInvokeFunc(nullInvokeFunc))
+
+	if err == nil {
+		t.Error("expected Serve to return an error but it did not")
+	}
+}
+
+func TestRequiresConfig(t *testing.T) {
+	m := New()
+	err := config.Configure(m, nil)
+
+	if err == nil {
+		t.Error("expected config.Configure to return an error but it did not")
+	}
+}
+
+func TestConfigureString_invalidCronspec(t *testing.T) {
+	m := New().(*cronSource)
+	err := m.ConfigureString("some invalid string")
+
+	if err == nil {
+		t.Error("expected ConfigureString to return an error but it did not")
 	}
 }
 


### PR DESCRIPTION
The TestInvoke test for the cron source was invalid because it did not
correctly check that the underlying function was invoked correctly.