### PR TITLE
Add Kafka source tests and add ignoreErrors option

### DIFF
--- a/pkg/run/source/kafka/consumer.go
+++ b/pkg/run/source/kafka/consumer.go
@@ -8,8 +8,9 @@ import (
 )
 
 type consumer struct {
-	ctx context.Context
-	f   fn.Fn
+	ctx          context.Context
+	f            fn.Fn
+	ignoreErrors bool
 }
 
 func (consumer *consumer) Setup(sarama.ConsumerGroupSession) error {
@@ -25,8 +26,8 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 		input := createInput(message)
 
 		_, err := consumer.f.Invoke(consumer.ctx, input)
-		if err != nil {
-			return err // TODO This MIGHT be wrong!
+		if err != nil && !consumer.ignoreErrors {
+			return err
 		}
 		session.MarkMessage(message, "")
 	}

--- a/pkg/run/source/kafka/consumer.go
+++ b/pkg/run/source/kafka/consumer.go
@@ -8,13 +8,11 @@ import (
 )
 
 type consumer struct {
-	ready chan bool
-	ctx   context.Context
-	f     fn.Fn
+	ctx context.Context
+	f   fn.Fn
 }
 
 func (consumer *consumer) Setup(sarama.ConsumerGroupSession) error {
-	close(consumer.ready)
 	return nil
 }
 
@@ -28,7 +26,7 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 
 		_, err := consumer.f.Invoke(consumer.ctx, input)
 		if err != nil {
-			return err
+			return err // TODO This MIGHT be wrong!
 		}
 		session.MarkMessage(message, "")
 	}

--- a/pkg/run/source/kafka/decode_hooks.go
+++ b/pkg/run/source/kafka/decode_hooks.go
@@ -1,0 +1,49 @@
+package kafka
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/Shopify/sarama"
+	"github.com/mitchellh/mapstructure"
+)
+
+func stringToBalanceStrategyHookFunc() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf((*sarama.BalanceStrategy)(nil)).Elem() {
+			return data, nil
+		}
+
+		strategyStr := data.(string)
+		var strategy sarama.BalanceStrategy
+
+		switch strategyStr {
+		case "sticky":
+			strategy = sarama.BalanceStrategySticky
+		case "roundrobin":
+			strategy = sarama.BalanceStrategyRoundRobin
+		case "range":
+			strategy = sarama.BalanceStrategyRange
+		default:
+			return nil, fmt.Errorf("unrecognized balance strategy: %q", strategyStr)
+		}
+
+		return strategy, nil
+	}
+}
+
+func stringToKafkaVersionHookFunc() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf((*sarama.KafkaVersion)(nil)).Elem() {
+			return data, nil
+		}
+
+		return sarama.ParseKafkaVersion(data.(string))
+	}
+}

--- a/pkg/run/source/kafka/decode_hooks_test.go
+++ b/pkg/run/source/kafka/decode_hooks_test.go
@@ -1,0 +1,121 @@
+package kafka
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/mitchellh/mapstructure"
+)
+
+func TestStringToBalanceStrategyHookFunc(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected sarama.BalanceStrategy
+	}{
+		{"sticky", sarama.BalanceStrategySticky},
+		{"roundrobin", sarama.BalanceStrategyRoundRobin},
+		{"range", sarama.BalanceStrategyRange},
+	}
+
+	for _, example := range tests {
+		output := &struct {
+			Other    string
+			Strategy sarama.BalanceStrategy
+		}{}
+
+		decoderConfig := &mapstructure.DecoderConfig{
+			Metadata:   nil,
+			Result:     output,
+			DecodeHook: stringToBalanceStrategyHookFunc(),
+		}
+
+		decoder, err := mapstructure.NewDecoder(decoderConfig)
+		if err != nil {
+			t.Fatalf("NewDecoder returned error: %+v", err)
+		}
+
+		err = decoder.Decode(map[string]interface{}{
+			"strategy": example.input,
+			"other":    "some other string",
+		})
+		if err != nil {
+			t.Fatalf("Decode returned error: %+v", err)
+		}
+
+		got := output.Strategy
+		want := example.expected
+
+		if got != want {
+			t.Errorf("Undesired output: want %v, got %v", want, got)
+		}
+	}
+}
+
+func TestStringToBalanceStrategyHookFunc_unrecognizedInput(t *testing.T) {
+	output := &struct {
+		Strategy sarama.BalanceStrategy
+	}{}
+
+	decoderConfig := &mapstructure.DecoderConfig{
+		Metadata:   nil,
+		Result:     output,
+		DecodeHook: stringToBalanceStrategyHookFunc(),
+	}
+
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		t.Fatalf("NewDecoder returned error: %+v", err)
+	}
+
+	err = decoder.Decode(map[string]interface{}{
+		"strategy": "someothervalue",
+	})
+	if err == nil {
+		t.Fatal("expected decoder.Decode to return an error but it did not")
+	}
+
+	got := err.Error()
+	want := `unrecognized balance strategy: "someothervalue"`
+
+	if !strings.Contains(got, want) {
+		t.Errorf("unexpected error message: wanted to contain %q, got %q", want, got)
+	}
+}
+
+func TestStringToKafkaVersionHookFunc(t *testing.T) {
+	output := &struct {
+		Other   string
+		Version sarama.KafkaVersion
+	}{}
+
+	decoderConfig := &mapstructure.DecoderConfig{
+		Metadata:   nil,
+		Result:     output,
+		DecodeHook: stringToKafkaVersionHookFunc(),
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		t.Fatalf("NewDecoder returned error: %+v", err)
+	}
+
+	err = decoder.Decode(map[string]interface{}{
+		"version": "2.1.1",
+		"other":   "some other value",
+	})
+	if err != nil {
+		t.Fatalf("Decode returned error: %+v", err)
+	}
+
+	gotOther := output.Other
+	wantOther := "some other value"
+	if gotOther != wantOther {
+		t.Errorf("incorrect Other value: want %q, got %q", wantOther, gotOther)
+	}
+
+	want := "2.1.1"
+	got := output.Version.String()
+	if want != got {
+		t.Errorf("incorrect Version value: want %q, got %q", want, got)
+	}
+}

--- a/pkg/run/source/kafka/kafka.go
+++ b/pkg/run/source/kafka/kafka.go
@@ -5,63 +5,57 @@ package kafka
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"strings"
 	"sync"
 
 	"github.com/Shopify/sarama"
 	"github.com/fnrun/fnrun/pkg/fn"
 	"github.com/fnrun/fnrun/pkg/run"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 )
 
-type kafkaSourceConfig struct {
-	Brokers  string `mapstructure:"brokers"`
-	Group    string `mapstructure:"group"`
-	Version  string `mapstructure:"version,omitempty"`
-	Topics   string `mapstructure:"topics"`
-	Assignor string `mapstructure:"assignor,omitempty"`
-	Oldest   bool   `mapstructure:"oldest,omitempty"`
-}
-
 type kafkaSource struct {
-	config *kafkaSourceConfig
+	Group    string
+	Brokers  []string
+	Topics   []string
+	Oldest   bool
+	Assignor sarama.BalanceStrategy
+	Version  sarama.KafkaVersion `mapstructure:",omitempty"`
+
+	client sarama.ConsumerGroup
 }
 
-func (k *kafkaSource) Serve(ctx context.Context, f fn.Fn) error {
-	version, err := sarama.ParseKafkaVersion(k.config.Version)
-	if err != nil {
-		return err
+func (k *kafkaSource) setUpConsumerGroup() error {
+	if k.client != nil {
+		return nil
 	}
 
 	config := sarama.NewConfig()
-	config.Version = version
+	config.Version = k.Version
+	config.Consumer.Group.Rebalance.Strategy = k.Assignor
 
-	switch k.config.Assignor {
-	case "sticky":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
-	case "roundrobin":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
-	case "range":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
-	default:
-		return fmt.Errorf("Unrecognized consumer group partition assignor: %s", k.config.Assignor)
-	}
-
-	if k.config.Oldest {
+	if k.Oldest {
 		config.Consumer.Offsets.Initial = sarama.OffsetOldest
 	}
 
-	consumer := consumer{
-		ready: make(chan bool),
-		ctx:   ctx,
-		f:     f,
+	client, err := sarama.NewConsumerGroup(k.Brokers, k.Group, config)
+	if err != nil {
+		return errors.Wrap(err, "error creating consumer group client")
+	}
+	k.client = client
+
+	return nil
+}
+
+func (k *kafkaSource) Serve(ctx context.Context, f fn.Fn) error {
+	if err := k.setUpConsumerGroup(); err != nil {
+		return err
 	}
 
-	client, err := sarama.NewConsumerGroup(strings.Split(k.config.Brokers, ","), k.config.Group, config)
-	if err != nil {
-		return fmt.Errorf("Error creating consumer group client: %v", err)
+	consumer := &consumer{
+		ctx: ctx,
+		f:   f,
 	}
 
 	wg := &sync.WaitGroup{}
@@ -69,23 +63,20 @@ func (k *kafkaSource) Serve(ctx context.Context, f fn.Fn) error {
 	go func() {
 		defer wg.Done()
 		for {
-			if err := client.Consume(ctx, strings.Split(k.config.Topics, ","), &consumer); err != nil {
-				log.Fatalf("Error from consumer: %v", err)
-			}
-
 			if ctx.Err() != nil {
 				return
 			}
-			consumer.ready = make(chan bool)
+
+			if err := k.client.Consume(ctx, k.Topics, consumer); err != nil {
+				log.Fatalf("Error from consumer: %v", err)
+			}
 		}
 	}()
 
-	<-consumer.ready
 	<-ctx.Done()
-
 	wg.Wait()
 
-	return client.Close()
+	return k.client.Close()
 }
 
 func (k *kafkaSource) RequiresConfig() bool {
@@ -93,20 +84,39 @@ func (k *kafkaSource) RequiresConfig() bool {
 }
 
 func (k *kafkaSource) ConfigureMap(configMap map[string]interface{}) error {
-	return mapstructure.Decode(configMap, k.config)
+	// Honor default value of sticky. There is an issue with trying to overwrite
+	// a sarama.BalanceStrategy when one already exists. It is not apparent to me
+	// exactly what the issue is, so the following code is in place to honor the
+	// existing default without actually setting the default value in the source
+	// upon instantiation.
+	if _, exists := configMap["assignor"]; !exists {
+		configMap["assignor"] = "sticky"
+	}
+
+	decoderConfig := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result:   k,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToSliceHookFunc(","),
+			stringToKafkaVersionHookFunc(),
+			stringToBalanceStrategyHookFunc(),
+		),
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(configMap)
 }
 
 // New returns a kafka source with default values. The resulting value must be
 // configured with at least broker and topic information before calling Serve.
 func New() run.Source {
+	version, _ := sarama.ParseKafkaVersion("2.1.1")
+
 	return &kafkaSource{
-		config: &kafkaSourceConfig{
-			Brokers:  "",
-			Group:    "",
-			Version:  "2.1.1",
-			Topics:   "",
-			Assignor: "range",
-			Oldest:   false,
-		},
+		Version: version,
+		Oldest:  false,
 	}
 }

--- a/pkg/run/source/kafka/kafka_test.go
+++ b/pkg/run/source/kafka/kafka_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -172,6 +173,7 @@ type testConsumerGroupHandler struct {
 	InputCh chan *sarama.ConsumerMessage
 	errorCh chan error
 	closed  bool
+	mutex   sync.Mutex
 }
 
 func (cg *testConsumerGroupHandler) Consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
@@ -191,6 +193,9 @@ func (cg *testConsumerGroupHandler) Errors() <-chan error {
 }
 
 func (cg *testConsumerGroupHandler) Close() error {
+	cg.mutex.Lock()
+	defer cg.mutex.Unlock()
+
 	if !cg.closed {
 		close(cg.InputCh)
 		close(cg.errorCh)

--- a/pkg/run/source/kafka/kafka_test.go
+++ b/pkg/run/source/kafka/kafka_test.go
@@ -1,0 +1,237 @@
+package kafka
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/fnrun/fnrun/pkg/fn"
+	"github.com/fnrun/fnrun/pkg/run/config"
+)
+
+func equals(t *testing.T, got, want interface{}) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("want %+v, got %+v", want, got)
+	}
+}
+
+func deepEquals(t *testing.T, got, want interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want %#v, got %#v", want, got)
+	}
+}
+
+func TestConfigure_invalidConfig(t *testing.T) {
+	k := New()
+	err := config.Configure(k, nil)
+
+	if err == nil {
+		t.Error("expected config.Configure to return an error but it did not")
+	}
+}
+
+func TestConfigureMap(t *testing.T) {
+	k := New().(*kafkaSource)
+	err := config.Configure(k, map[string]interface{}{
+		"group":    "myGroupName",
+		"brokers":  "1.2.3.4,2.3.4.5",
+		"topics":   "topicA,topicB",
+		"oldest":   true,
+		"version":  "2.1.0",
+		"assignor": "roundrobin",
+	})
+
+	if err != nil {
+		t.Fatalf("config.Configure returned an error: %+v", err)
+	}
+
+	equals(t, k.Group, "myGroupName")
+	deepEquals(t, k.Brokers, []string{"1.2.3.4", "2.3.4.5"})
+	deepEquals(t, k.Topics, []string{"topicA", "topicB"})
+	equals(t, k.Oldest, true)
+	equals(t, k.Version.String(), "2.1.0")
+	equals(t, k.Assignor.Name(), sarama.BalanceStrategyRoundRobin.Name())
+}
+
+func TestConfigureMap_invalidMapValue(t *testing.T) {
+	k := New().(*kafkaSource)
+	err := config.Configure(k, map[string]interface{}{
+		"oldest": 3,
+	})
+
+	if err == nil {
+		t.Fatal("expected config.Configure to return an error but it did not")
+	}
+}
+
+func TestServe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client := newTestConsumerGroupHandler()
+	k := &kafkaSource{
+		client: client,
+	}
+
+	capturedInputCh := make(chan interface{}, 1)
+
+	f := fn.NewFnFromInvokeFunc(func(ctx context.Context, input interface{}) (interface{}, error) {
+		cancel()
+		capturedInputCh <- input
+		return input, nil
+	})
+
+	client.InputCh <- newConsumerMessage("my-topic", []byte("some key"), []byte("some value"))
+	if err := k.Serve(ctx, f); err != nil {
+		t.Fatal(err)
+	}
+
+	capturedInput := (<-capturedInputCh).(map[string]interface{})
+
+	gotInput := map[string]interface{}{
+		"key":   capturedInput["key"],
+		"value": capturedInput["value"],
+		"topic": capturedInput["topic"],
+	}
+	wantInput := map[string]interface{}{
+		"key":   "some key",
+		"value": "some value",
+		"topic": "my-topic",
+	}
+
+	if !reflect.DeepEqual(gotInput, wantInput) {
+		t.Errorf("unexpected input value: want %#v, got %#v", wantInput, gotInput)
+	}
+}
+
+func newConsumerMessage(topic string, key, value []byte) *sarama.ConsumerMessage {
+	return &sarama.ConsumerMessage{
+		Headers:        []*sarama.RecordHeader{},
+		Timestamp:      time.Now(),
+		BlockTimestamp: time.Now(),
+		Topic:          topic,
+		Key:            key,
+		Value:          value,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Mock consumer group handler
+
+type testConsumerGroupHandler struct {
+	InputCh chan *sarama.ConsumerMessage
+	errorCh chan error
+	closed  bool
+}
+
+func (cg *testConsumerGroupHandler) Consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+	session := &testConsumerGroupSession{Ctx: ctx}
+	claim := newTestConsumerGroupClaim(session, cg.InputCh)
+
+	go func() {
+		<-ctx.Done()
+		cg.Close()
+	}()
+
+	return handler.ConsumeClaim(session, claim)
+}
+
+func (cg *testConsumerGroupHandler) Errors() <-chan error {
+	return cg.errorCh
+}
+
+func (cg *testConsumerGroupHandler) Close() error {
+	if !cg.closed {
+		close(cg.InputCh)
+		close(cg.errorCh)
+		cg.closed = true
+	}
+
+	return nil
+}
+
+func newTestConsumerGroupHandler() *testConsumerGroupHandler {
+	return &testConsumerGroupHandler{
+		InputCh: make(chan *sarama.ConsumerMessage, 10),
+		errorCh: make(chan error),
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Mock consumer group session
+
+type testConsumerGroupSession struct {
+	Ctx context.Context
+}
+
+var _ sarama.ConsumerGroupSession = (*testConsumerGroupSession)(nil)
+
+func (sess *testConsumerGroupSession) Claims() map[string][]int32 {
+	return map[string][]int32{}
+}
+
+func (sess *testConsumerGroupSession) MemberID() string {
+	return ""
+}
+
+func (sess *testConsumerGroupSession) GenerationID() int32 {
+	return 0
+}
+
+func (sess *testConsumerGroupSession) MarkOffset(topic string, partition int32, offset int64, metadata string) {
+}
+
+func (sess *testConsumerGroupSession) Commit() {
+}
+
+func (sess *testConsumerGroupSession) ResetOffset(topic string, partition int32, offset int64, metadata string) {
+}
+
+func (sess *testConsumerGroupSession) MarkMessage(msg *sarama.ConsumerMessage, metadata string) {
+}
+
+func (sess *testConsumerGroupSession) Context() context.Context {
+	return sess.Ctx
+}
+
+// -----------------------------------------------------------------------------
+// Mock consumer group claim
+
+type testConsumerGroupClaim struct {
+	messageChan <-chan *sarama.ConsumerMessage
+	session     *testConsumerGroupSession
+}
+
+func (gc *testConsumerGroupClaim) Topic() string {
+	return ""
+}
+
+func (gc *testConsumerGroupClaim) Partition() int32 {
+	return 0
+}
+
+func (gc *testConsumerGroupClaim) InitialOffset() int64 {
+	return 0
+}
+
+func (gc *testConsumerGroupClaim) HighWaterMarkOffset() int64 {
+	return 0
+}
+
+func (gc *testConsumerGroupClaim) Messages() <-chan *sarama.ConsumerMessage {
+	return gc.messageChan
+}
+
+func newTestConsumerGroupClaim(session *testConsumerGroupSession, ch <-chan *sarama.ConsumerMessage) *testConsumerGroupClaim {
+	claim := testConsumerGroupClaim{
+		messageChan: ch,
+		session:     session,
+	}
+
+	return &claim
+}


### PR DESCRIPTION
The ignoreErrors option will be false by default. This option is useful
if a user has middleware that handles an error or does not want
execution to stop in the face of errors.