### PR TITLE
Add restart options to fnrunner

### DIFF
--- a/changes/unreleased/Added-20210905-134547.yaml
+++ b/changes/unreleased/Added-20210905-134547.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: fnrunner restart options

--- a/changes/unreleased/Changed-20210905-134618.yaml
+++ b/changes/unreleased/Changed-20210905-134618.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '**Breaking** fnrunner restarts after 10s by default after receiving an
+  error while serving'


### PR DESCRIPTION
This commit adds the restart and restart-wait CLI options to fnrunner. 

The `restart` option defaults to true and the `restart-wait` option defaults to 10 seconds. These options are used to restart a running system if it fails (e.g., due to network errors). 

fnrunner will panic when it receives an error running a system and `restart` is set to false.