### PR TITLE
Return error when specifying az msg disposition fails

### DIFF
--- a/changes/unreleased/Fixed-20210907-230619.yaml
+++ b/changes/unreleased/Fixed-20210907-230619.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: return error from Azure ServiceBus source when renew lock operation fails instead
+  of causing infinite loop
+time: 2021-09-07T23:06:19.763607-05:00

--- a/run/source/azure/servicebus/servicebus.go
+++ b/run/source/azure/servicebus/servicebus.go
@@ -86,11 +86,11 @@ func (q *queueSource) serveQueue(ctx context.Context, queue *servicebus.Queue, f
 			if err != nil {
 				log.Printf("Abandoning due to error: %+v\n", err)
 				if err = msg.Abandon(newCtx); err != nil {
-					log.Printf("Error abandoning message: %+v\n", err)
+					return err
 				}
 			} else {
 				if err = msg.Complete(newCtx); err != nil {
-					log.Printf("Error completing message: %+v\n", err)
+					return err
 				}
 			}
 


### PR DESCRIPTION
Renewing message locks with the Azure ServiceBus library will fail after idling for approximately 2 hours due to a bug in the library. This commit provides a workaround by returning an error from the Serve function when setting the message disposition fails. This may occur when a call to RenewLocks fails and the internal context is canceled.

If the runner restarts the system, it will establish a new connection and should run as expected.